### PR TITLE
solution to style columns bg_color and font_color bug, ability to protect cells and more support.

### DIFF
--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -104,8 +104,7 @@ class StyleFrame(object):
 
             column_as_letter = None
             if column_to_convert in self.data_df.columns:  # column name
-                column_index = self.data_df.columns.get_loc(
-                    column_to_convert) + startcol + 1  # worksheet columns index start from 1
+                column_index = self.data_df.columns.get_loc(column_to_convert) + startcol + 1  # worksheet columns index start from 1
                 column_as_letter = openpyxl.cell.get_column_letter(column_index)
 
             elif isinstance(column_to_convert, int) and column_to_convert >= 1:  # column index
@@ -122,10 +121,9 @@ class StyleFrame(object):
 
         export_df.columns = [col.value for col in export_df.columns]
 
-        export_df.to_excel(excel_writer, sheet_name=sheet_name, na_rep=na_rep, float_format=float_format,
-                           columns=columns,
-                           header=header, index=index, index_label=index_label, startrow=startrow, startcol=startcol,
-                           engine='openpyxl', merge_cells=merge_cells, encoding=encoding, inf_rep=inf_rep)
+        export_df.to_excel(excel_writer, sheet_name=sheet_name, na_rep=na_rep, float_format=float_format, index=index,
+                           columns=columns, header=header, index_label=index_label, startrow=startrow,
+                           startcol=startcol, engine='openpyxl', merge_cells=merge_cells, encoding=encoding, inf_rep=inf_rep)
 
         sheet = excel_writer.book.get_sheet_by_name(sheet_name)
 
@@ -207,9 +205,8 @@ class StyleFrame(object):
                                                    font_color=font_color, protection=protection,
                                                    number_format=number_format).create_style()
 
-    def apply_column_style(self, cols_to_style, bg_color=colors.white, bold=False, font_size=12,
-                           font_color=colors.black, protection=False, style_header=False,
-                           number_format=number_formats.general):
+    def apply_column_style(self, cols_to_style, bg_color=colors.white, bold=False, font_size=12, protection=False,
+                           font_color=colors.black, style_header=False, number_format=number_formats.general):
         """
         apply style to a whole column
         :param cols_to_style: the columns to apply the style to

--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -65,7 +65,7 @@ class StyleFrame(object):
             raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, attr))
 
     @classmethod
-    def read_excel(cls, path, sheetname, **kwargs):
+    def read_excel(cls, path, sheetname=0, **kwargs):
         return StyleFrame(pd.read_excel(path, sheetname=sheetname, **kwargs))
 
     @classmethod

--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -199,6 +199,9 @@ class StyleFrame(object):
             cols_to_style = [cols_to_style]
         elif cols_to_style is None:
             cols_to_style = list(self.data_df.columns)
+        if not isinstance(indexes_to_style, (list, tuple)):
+            indexes_to_style = [indexes_to_style]
+
         for index in indexes_to_style:
             for col in cols_to_style:
                 self.ix[index, col].style = Styler(bg_color=bg_color, bold=bold, font_size=font_size,

--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -280,7 +280,7 @@ class StyleFrame(object):
         try:
             height = float(height)
         except TypeError:
-            raise TypeError('rows width must be numeric value')
+            raise TypeError('rows height must be numeric value')
 
         if height <= 0:
             raise ValueError('rows width must be positive')

--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -98,7 +98,7 @@ class StyleFrame(object):
                     return x
 
         def get_column_as_letter(column_to_convert):
-            if not isinstance(column_to_convert, (int, basestring)):
+            if not isinstance(column_to_convert, (int, basestring, Container)):
                     raise TypeError("column must be an index, column letter or column name")
 
             column_as_letter = None
@@ -264,7 +264,7 @@ class StyleFrame(object):
             raise ValueError('columns width must be positive')
 
         for column in columns:
-            if not isinstance(column, (int, basestring)):
+            if not isinstance(column, (int, basestring, Container)):
                 raise TypeError("column must be an index, column letter or column name")
             self.columns_width[column] = width
 
@@ -284,10 +284,12 @@ class StyleFrame(object):
 
         if height <= 0:
             raise ValueError('rows width must be positive')
-
         for row in rows:
-            if not isinstance(row, int):
+            try:
+                row = int(row)
+            except TypeError:
                 raise TypeError("row must be an index")
+
             self.rows_height[row] = height
 
     def rename(self, columns=None, inplace=False):

--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -13,6 +13,7 @@ class StyleFrame(object):
     A wrapper class that wraps pandas DataFrame.
     Stores container objects that have values and Styles that will be applied to excel
     """
+
     def __init__(self, obj):
         if isinstance(obj, pd.DataFrame):
             self.data_df = obj.applymap(lambda x: Container(x) if not isinstance(x, Container) else x)
@@ -72,14 +73,16 @@ class StyleFrame(object):
     def ExcelWriter(cls, path):
         return pd.ExcelWriter(path, engine='openpyxl')
 
-    def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='', float_format=None, columns=None, header=True, index=False,
+    def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='', float_format=None, columns=None, header=True,
+                 index=False,
                  index_label=None, startrow=0, startcol=0, merge_cells=True, encoding=None, inf_rep='inf',
-                 right_to_left=True, columns_to_hide=None):
+                 allow_protection=False, right_to_left=True, columns_to_hide=None):
         """
         Saves the dataframe to excel and applies the styles.
         :param right_to_left: sets the sheet to be right to left.
         :param columns_to_hide: single column, list or tuple of columns to hide, may be column index (starts from 1)
                                 column name or column letter.
+        :param allow_protection: protect the sheet and the cells that specified as protected.
         Read Pandas' documentation about the other parameters
         """
         if index:
@@ -99,11 +102,12 @@ class StyleFrame(object):
 
         def get_column_as_letter(column_to_convert):
             if not isinstance(column_to_convert, (int, basestring, Container)):
-                    raise TypeError("column must be an index, column letter or column name")
+                raise TypeError("column must be an index, column letter or column name")
 
             column_as_letter = None
             if column_to_convert in self.data_df.columns:  # column name
-                column_index = self.data_df.columns.get_loc(column_to_convert) + startcol + 1  # worksheet columns index start from 1
+                column_index = self.data_df.columns.get_loc(
+                    column_to_convert) + startcol + 1  # worksheet columns index start from 1
                 column_as_letter = openpyxl.cell.get_column_letter(column_index)
 
             elif isinstance(column_to_convert, int) and column_to_convert >= 1:  # column index
@@ -120,11 +124,14 @@ class StyleFrame(object):
 
         export_df.columns = [col.value for col in export_df.columns]
 
-        export_df.to_excel(excel_writer, sheet_name=sheet_name, na_rep=na_rep, float_format=float_format, columns=columns,
+        export_df.to_excel(excel_writer, sheet_name=sheet_name, na_rep=na_rep, float_format=float_format,
+                           columns=columns,
                            header=header, index=index, index_label=index_label, startrow=startrow, startcol=startcol,
                            engine='openpyxl', merge_cells=merge_cells, encoding=encoding, inf_rep=inf_rep)
 
         sheet = excel_writer.book.get_sheet_by_name(sheet_name)
+
+        sheet.protection.sheet = allow_protection
 
         sheet.sheet_view.rightToLeft = right_to_left
 
@@ -162,7 +169,7 @@ class StyleFrame(object):
         if columns_to_hide is not None:
             if not isinstance(columns_to_hide, (list, tuple)):
                 columns_to_hide = [columns_to_hide]
-            
+
             for column in columns_to_hide:
                 column_letter = get_column_as_letter(column_to_convert=column)
                 sheet.column_dimensions[column_letter].hidden = True
@@ -177,7 +184,8 @@ class StyleFrame(object):
             else:
                 raise IndexError('row: %s is out of range' % row)
 
-    def apply_style_by_indexes(self, indexes_to_style=None, cols_to_style=None, bg_color=colors.white, bold=False,
+    # CHANGED
+    def apply_style_by_indexes(self, indexes_to_style, cols_to_style=None, bg_color=colors.white, bold=False,
                                font_size=12, font_color=colors.black, number_format=number_formats.general):
         """
         applies a certain style to the provided indexes in the dataframe in the provided columns
@@ -191,7 +199,7 @@ class StyleFrame(object):
         :return:
         """
         if cols_to_style is not None and not isinstance(cols_to_style, (list, tuple)):
-            raise TypeError("cols_name must be a list or a tuple")
+            cols_to_style = [cols_to_style]
         elif cols_to_style is None:
             cols_to_style = list(self.data_df.columns)
         for index in indexes_to_style:
@@ -199,8 +207,10 @@ class StyleFrame(object):
                 self.ix[index, col].style = Styler(bg_color=bg_color, bold=bold, font_size=font_size,
                                                    font_color=font_color, number_format=number_format).create_style()
 
-    def apply_column_style(self, cols_to_style=None, bg_color=colors.white, bold=False, font_size=12, font_color=colors.black,
-                           style_header=False, number_format=number_formats.general):
+    # CHANGED
+    def apply_column_style(self, cols_to_style, bg_color=colors.white, bold=False, font_size=12,
+                           font_color=colors.black, protection=False, style_header=False,
+                           number_format=number_formats.general):
         """
         apply style to a whole column
         :param cols_to_style: the columns to apply the style to
@@ -210,16 +220,19 @@ class StyleFrame(object):
         :param font_color: the font color
         :param style_header: style the header or not
         :param number_format: style the number format
+        :param protection: to protect the column from changes or not
         :return:
         """
         if not isinstance(cols_to_style, (list, tuple)):
-            raise TypeError("cols_name must be a list or a tuple")
+            cols_to_style = [cols_to_style]
+        print protection
         if not all(col in self.columns for col in cols_to_style):
             raise KeyError("one of the columns in {} wasn't found".format(cols_to_style))
         for col_name in cols_to_style:
             if style_header:
                 self.columns[self.columns.get_loc(col_name)].style = Styler(bg_color=bg_color, bold=bold,
                                                                             font_size=font_size, font_color=font_color,
+                                                                            protection=protection,
                                                                             number_format=number_format).create_style()
             for index in self.index:
                 if isinstance(self.ix[index, col_name].value, pd.tslib.Timestamp):
@@ -229,10 +242,11 @@ class StyleFrame(object):
                 elif isinstance(self.ix[index, col_name].value, dt.time):
                     number_format = number_formats.time_24_hours
                 self.ix[index, col_name].style = Styler(bg_color=bg_color, bold=bold, font_size=font_size,
-                                                        font_color=font_color, number_format=number_format).create_style()
+                                                        protection=protection, font_color=font_color,
+                                                        number_format=number_format).create_style()
 
     def apply_headers_style(self, bg_color=colors.white, bold=True, font_size=12, font_color=colors.black,
-                            number_format=number_formats.general):
+                            protection=False, number_format=number_formats.general):
         """
         apply style to the headers only
         :param bg_color:the color to use
@@ -243,8 +257,8 @@ class StyleFrame(object):
         :return:
         """
         for column in self.data_df.columns:
-            column.style = Styler(bg_color=bg_color, bold=bold, font_size=font_size,
-                                  font_color=font_color, number_format=number_format).create_style()
+            column.style = Styler(bg_color=bg_color, bold=bold, font_size=font_size, font_color=font_color,
+                                  protection=protection, number_format=number_format).create_style()
 
     def set_column_width(self, columns, width):
         """

--- a/StyleFrame/style_frame.py
+++ b/StyleFrame/style_frame.py
@@ -13,7 +13,6 @@ class StyleFrame(object):
     A wrapper class that wraps pandas DataFrame.
     Stores container objects that have values and Styles that will be applied to excel
     """
-
     def __init__(self, obj):
         if isinstance(obj, pd.DataFrame):
             self.data_df = obj.applymap(lambda x: Container(x) if not isinstance(x, Container) else x)
@@ -74,15 +73,14 @@ class StyleFrame(object):
         return pd.ExcelWriter(path, engine='openpyxl')
 
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='', float_format=None, columns=None, header=True,
-                 index=False,
-                 index_label=None, startrow=0, startcol=0, merge_cells=True, encoding=None, inf_rep='inf',
+                 index=False, index_label=None, startrow=0, startcol=0, merge_cells=True, encoding=None, inf_rep='inf',
                  allow_protection=False, right_to_left=True, columns_to_hide=None):
         """
         Saves the dataframe to excel and applies the styles.
         :param right_to_left: sets the sheet to be right to left.
         :param columns_to_hide: single column, list or tuple of columns to hide, may be column index (starts from 1)
                                 column name or column letter.
-        :param allow_protection: protect the sheet and the cells that specified as protected.
+        :param allow_protection: allow to protect the sheet and the cells that specified as protected.
         Read Pandas' documentation about the other parameters
         """
         if index:
@@ -184,9 +182,9 @@ class StyleFrame(object):
             else:
                 raise IndexError('row: %s is out of range' % row)
 
-    # CHANGED
     def apply_style_by_indexes(self, indexes_to_style, cols_to_style=None, bg_color=colors.white, bold=False,
-                               font_size=12, font_color=colors.black, number_format=number_formats.general):
+                               font_size=12, font_color=colors.black, protection=False,
+                               number_format=number_formats.general):
         """
         applies a certain style to the provided indexes in the dataframe in the provided columns
         :param indexes_to_style: indexes to apply the style to
@@ -195,6 +193,7 @@ class StyleFrame(object):
         :param bold: bold or not
         :param font_size: the font size
         :param font_color: the font color
+        :param protection: to protect the cell from changes or not
         :param number_format: style the number format
         :return:
         """
@@ -205,9 +204,9 @@ class StyleFrame(object):
         for index in indexes_to_style:
             for col in cols_to_style:
                 self.ix[index, col].style = Styler(bg_color=bg_color, bold=bold, font_size=font_size,
-                                                   font_color=font_color, number_format=number_format).create_style()
+                                                   font_color=font_color, protection=protection,
+                                                   number_format=number_format).create_style()
 
-    # CHANGED
     def apply_column_style(self, cols_to_style, bg_color=colors.white, bold=False, font_size=12,
                            font_color=colors.black, protection=False, style_header=False,
                            number_format=number_formats.general):
@@ -225,7 +224,6 @@ class StyleFrame(object):
         """
         if not isinstance(cols_to_style, (list, tuple)):
             cols_to_style = [cols_to_style]
-        print protection
         if not all(col in self.columns for col in cols_to_style):
             raise KeyError("one of the columns in {} wasn't found".format(cols_to_style))
         for col_name in cols_to_style:

--- a/StyleFrame/styler.py
+++ b/StyleFrame/styler.py
@@ -1,6 +1,6 @@
 # coding:utf-8
 from openpyxl.styles import PatternFill, Style, Color, Border, Side, Font, Alignment, colors as op_colors
-
+import re
 
 class Styler(object):
     """
@@ -8,23 +8,36 @@ class Styler(object):
     """
     def __init__(self, bg_color='white', bold=False, font_size=12, font_color='black', number_format='General',
                  underline=None):
-        self.bg_color = bg_color
         self.bold = bold
         self.font_size = font_size
         self.font_color = font_color
         self.number_format = number_format
         self.underline = underline
+        if self.is_string_is_hex_color_code(hex_string=bg_color):
+            self.bg_color = bg_color
+        else:
+            self.bg_color = colors.get(bg_color, colors.white)
+
+        if self.is_string_is_hex_color_code(hex_string=font_color):
+            self.font_color = font_color
+        else:
+            self.font_color = colors.get(self.font_color, colors.black)
 
     def create_style(self):
         side = Side(border_style='thin', color=colors.black)
         border = Border(left=side, right=side, top=side, bottom=side)
-        return Style(font=Font(name="Arial", size=self.font_size, color=Color(colors.get(self.font_color, colors.black)),
+        return Style(font=Font(name="Arial", size=self.font_size, color=Color(self.font_color),
                                bold=self.bold, underline=self.underline),
-                     fill=PatternFill(patternType='solid', fgColor=Color(colors.get(self.bg_color, colors.white))),
+                     fill=PatternFill(patternType='solid', fgColor=self.bg_color),
                      alignment=Alignment(horizontal='center', vertical='center', wrap_text=True, shrink_to_fit=True, indent=0),
                      border=border,
                      number_format=self.number_format)
 
+    def is_string_is_hex_color_code(self, hex_string):
+        if re.search(r'[a-fA-F0-9]{6}$', hex_string):
+            return True
+        else:
+            return False
 
 def not_supported(*args, **kwargs):
         raise NotImplementedError('ImmutableDict is immutable')
@@ -47,4 +60,4 @@ number_formats = ImmutableDict(general='General', date='DD/MM/YY', percent='0.0%
                                thousands_comma_sep='#,##0')
 
 colors = ImmutableDict(white='FFFFFF', blue=op_colors.BLUE, yellow=op_colors.YELLOW, green=op_colors.GREEN,
-                       black=op_colors.BLACK, red=op_colors.RED, purple='800080')
+                       black=op_colors.BLACK, red=op_colors.RED, purple='800080', grey='D3D3D3',)

--- a/StyleFrame/styler.py
+++ b/StyleFrame/styler.py
@@ -13,11 +13,16 @@ class Styler(object):
         self.font_color = font_color
         self.number_format = number_format
         self.underline = underline
+
+        if bg_color[0] == '#':
+            bg_color = bg_color[1:]
         if self.is_string_is_hex_color_code(hex_string=bg_color):
             self.bg_color = bg_color
         else:
             self.bg_color = colors.get(bg_color, colors.white)
 
+        if font_color[0] == '#':
+            font_color = font_color[1:]
         if self.is_string_is_hex_color_code(hex_string=font_color):
             self.font_color = font_color
         else:

--- a/StyleFrame/styler.py
+++ b/StyleFrame/styler.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-from openpyxl.styles import PatternFill, Style, Color, Border, Side, Font, Alignment, colors as op_colors
+from openpyxl.styles import PatternFill, Style, Color, Border, Side, Font, Alignment, Protection, colors as op_colors
 import re
 
 class Styler(object):
@@ -7,11 +7,12 @@ class Styler(object):
     Creates openpyxl Style to be applied
     """
     def __init__(self, bg_color='white', bold=False, font_size=12, font_color='black', number_format='General',
-                 underline=None):
+                 protection=False, underline=None):
         self.bold = bold
         self.font_size = font_size
         self.font_color = font_color
         self.number_format = number_format
+        self.protection = protection
         self.underline = underline
 
         if bg_color[0] == '#':
@@ -36,13 +37,15 @@ class Styler(object):
                      fill=PatternFill(patternType='solid', fgColor=self.bg_color),
                      alignment=Alignment(horizontal='center', vertical='center', wrap_text=True, shrink_to_fit=True, indent=0),
                      border=border,
-                     number_format=self.number_format)
+                     number_format=self.number_format,
+                     protection=Protection(locked=self.protection))
 
     def is_string_is_hex_color_code(self, hex_string):
         if re.search(r'[a-fA-F0-9]{6}$', hex_string):
             return True
         else:
             return False
+
 
 def not_supported(*args, **kwargs):
         raise NotImplementedError('ImmutableDict is immutable')


### PR DESCRIPTION
1. fixed bug of styling columns bg_color and font_color. 
2. supporting Containers as columns to style. 
3. supporting numpy integers as rows to style.
4. supporting hex color code as bg_color and font_color. 
5. added the color grey to colors.
6. added the ability to protect cells, for example:
![3](https://cloud.githubusercontent.com/assets/12184646/9717335/a286f214-557a-11e5-9734-0d0eba8f34d4.png)

