### PR TITLE
Read version.py file and parse version, remove project import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,27 @@
+import codecs
+import os
+import re
+
 from setuptools import setup, find_packages
-from StyleFrame.version import _version_
 
 DESCRIPTION = 'A library that wraps pandas and openpyxl and allows easy styling of dataframes in excel. Documentation can be found at http://styleframe.readthedocs.org'
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+    # intentionally *not* adding an encoding option to open
+    return codecs.open(os.path.join(here, *parts), 'r').read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^_version_ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name='StyleFrame',
@@ -9,7 +29,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version=_version_,
+    version=find_version('StyleFrame', 'version.py'),
 
     description=DESCRIPTION,
     long_description=DESCRIPTION,


### PR DESCRIPTION
Thanks for building this library, it's been super helpful!

I ran into a problem trying to install this project in a clean virtualenv, and I realized that `setup.py` _imports_ the project, which required the dependencies to be present already. I noticed the import is _only_ being used to parse the project's version.

Following some of the open-source Python conventions, I thought it might be worth modifying `setup.py` to be more in line with how these are often built.

check out the standard requests library as an example:

- [requests](https://github.com/kennethreitz/requests/blob/9742da7f91f595796a412a8150aacc00191be039/setup.py#L61)

## Changes

- Read `version.py` file and parse version
- Remove project import