### PR TITLE
Allow newer versions of jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['openpyxl>=2.5', 'xlrd==1.0.0', 'colour>=0.1.5', 'jsonschema==2.6.0'],
+    install_requires=['openpyxl>=2.5', 'xlrd==1.0.0', 'colour>=0.1.5', 'jsonschema'],
     extras_require={
         ':python_version <= "3.4"': [
             'pandas >= 0.16.2, <= 0.22.*'


### PR DESCRIPTION
Tests pass with jsonschema 3.0.1, so this looks good.