### PR TITLE
Beginning refactor `to_excel()`

### DIFF
--- a/styleframe/style_frame.py
+++ b/styleframe/style_frame.py
@@ -387,8 +387,10 @@ class StyleFrame:
                       calling ``StyleFrame.to_excel`` by directly modifying ``StyleFrame.A_FACTOR`` and ``StyleFrame.P_FACTOR``
 
         :type best_fit: None or str or list or tuple or set
-        :param index: Write row names.
-        :type index: bool
+
+        .. versionadded:: 4.2
+
+        :param bool index: Write row names.
         :rtype: :class:`pandas.ExcelWriter`
 
         """
@@ -397,7 +399,7 @@ class StyleFrame:
             if excel_writer.engine != 'openpyxl':
                 raise TypeError('styleframe supports only openpyxl, attempted to use {}'.format(excel_writer.engine))
 
-        header, startcol, startrow, na_rep = StyleFrame._to_excel_pandas_defaults(kwargs)
+        header, startcol, startrow, na_rep = self._to_excel_pandas_defaults(kwargs)
 
         def get_values(x):
             if isinstance(x, Container):

--- a/styleframe/style_frame.py
+++ b/styleframe/style_frame.py
@@ -336,10 +336,10 @@ class StyleFrame:
         return tuple(range(1, len(self) + 2))
 
     @staticmethod
-    def _to_excel_pandas_defaults(kwargs):
-        """Return five arguments used by `pandas.DataFrame.to_excel()` and
-        use default values in case that arguments not explicit set.
+    def _to_excel_pandas_defaults(kwargs: Dict[str, Any]) -> Tuple[bool, int, int, str]:
+        """Returns the provided or default values for specific arguments as set by :meth:`pandas.DataFrame.to_excel`
         """
+
         header = kwargs.pop('header', True)
         startcol = kwargs.pop('startcol', 0)
         startrow = kwargs.pop('startrow', 0)

--- a/styleframe/style_frame.py
+++ b/styleframe/style_frame.py
@@ -335,10 +335,23 @@ class StyleFrame:
 
         return tuple(range(1, len(self) + 2))
 
+    @staticmethod
+    def _to_excel_pandas_defaults(kwargs):
+        """Return five arguments used by `pandas.DataFrame.to_excel()` and
+        use default values in case that arguments not explicit set.
+        """
+        header = kwargs.pop('header', True)
+        startcol = kwargs.pop('startcol', 0)
+        startrow = kwargs.pop('startrow', 0)
+        na_rep = kwargs.pop('na_rep', '')
+
+        return header, startcol, startrow, na_rep
+
     def to_excel(self, excel_writer: Union[str, pd.ExcelWriter, pathlib.Path] = 'output.xlsx',
                  sheet_name: str = 'Sheet1', allow_protection: bool = False, right_to_left: bool = False,
                  columns_to_hide: Union[None, str, list, tuple, set] = None, row_to_add_filters: Optional[int] = None,
                  columns_and_rows_to_freeze: Optional[str] = None, best_fit: Union[None, str, list, tuple, set] = None,
+                 index: bool = False,
                  **kwargs) -> pd.ExcelWriter:
         """Saves the dataframe to excel and applies the styles.
 
@@ -374,6 +387,8 @@ class StyleFrame:
                       calling ``StyleFrame.to_excel`` by directly modifying ``StyleFrame.A_FACTOR`` and ``StyleFrame.P_FACTOR``
 
         :type best_fit: None or str or list or tuple or set
+        :param index: Write row names.
+        :type index: bool
         :rtype: :class:`pandas.ExcelWriter`
 
         """
@@ -382,12 +397,7 @@ class StyleFrame:
             if excel_writer.engine != 'openpyxl':
                 raise TypeError('styleframe supports only openpyxl, attempted to use {}'.format(excel_writer.engine))
 
-        # dealing with needed pandas.to_excel defaults
-        header = kwargs.pop('header', True)
-        index = kwargs.pop('index', False)
-        startcol = kwargs.pop('startcol', 0)
-        startrow = kwargs.pop('startrow', 0)
-        na_rep = kwargs.pop('na_rep', '')
+        header, startcol, startrow, na_rep = StyleFrame._to_excel_pandas_defaults(kwargs)
 
         def get_values(x):
             if isinstance(x, Container):

--- a/styleframe/style_frame.py
+++ b/styleframe/style_frame.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from copy import deepcopy
 from functools import partial
-from typing import Union, Optional, List, Dict, Tuple, Set
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/styleframe/tests/style_frame_tests.py
+++ b/styleframe/tests/style_frame_tests.py
@@ -1,6 +1,6 @@
+import inspect
 import os
 import unittest
-import inspect
 
 from functools import partial
 
@@ -675,18 +675,9 @@ class StyleFrameTest(unittest.TestCase):
         self.sf.columns = ['c', 'd']
         self.assertTrue(all(isinstance(col, Container) for col in self.sf.columns))
         self.assertEqual([col.value for col in self.sf.columns], ['c', 'd'])
-
-
-class ToExcel(unittest.TestCase):
-    """Tests related to `StyleFrame.to_excel()`.
-    """
-
-    def test_pandas_defaults(self):
-        """
-        """
+    def test_to_excel_pandas_defaults(self):
         # values that StyleFrame assume as pandas defaults
-        header, startcol, startrow, na_rep \
-            = StyleFrame._to_excel_pandas_defaults({})
+        header, startcol, startrow, na_rep = StyleFrame._to_excel_pandas_defaults({})
 
         # the "real" default values pandas use
         sig = inspect.signature(pd.DataFrame.to_excel)
@@ -696,3 +687,4 @@ class ToExcel(unittest.TestCase):
         self.assertEqual(startcol, sig.parameters['startcol'].default)
         self.assertEqual(startrow, sig.parameters['startrow'].default)
         self.assertEqual(na_rep, sig.parameters['na_rep'].default)
+

--- a/styleframe/tests/style_frame_tests.py
+++ b/styleframe/tests/style_frame_tests.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import inspect
 
 from functools import partial
 
@@ -674,3 +675,24 @@ class StyleFrameTest(unittest.TestCase):
         self.sf.columns = ['c', 'd']
         self.assertTrue(all(isinstance(col, Container) for col in self.sf.columns))
         self.assertEqual([col.value for col in self.sf.columns], ['c', 'd'])
+
+
+class ToExcel(unittest.TestCase):
+    """Tests related to `StyleFrame.to_excel()`.
+    """
+
+    def test_pandas_defaults(self):
+        """
+        """
+        # values that StyleFrame assume as pandas defaults
+        header, startcol, startrow, na_rep \
+            = StyleFrame._to_excel_pandas_defaults({})
+
+        # the "real" default values pandas use
+        sig = inspect.signature(pd.DataFrame.to_excel)
+
+        # compare them
+        self.assertEqual(header, sig.parameters['header'].default)
+        self.assertEqual(startcol, sig.parameters['startcol'].default)
+        self.assertEqual(startrow, sig.parameters['startrow'].default)
+        self.assertEqual(na_rep, sig.parameters['na_rep'].default)


### PR DESCRIPTION
As discussed in #135

 - The `index` now is an explicit argument in `to_excel()` with default `False` (differing from pandas default). This is to make it clear to the user that there is a difference between StyleFrame- and Pandas-default for that argument.
 - Setting the default's for `header`, `startcol`, `startrow` and `na_rep` now moved to an own method (`_to_excel_pandas_defaults()`). This makes it easier to test this piece of code and make the code of `to_excel()` more clear.

Sidenode: There are nearly no docstrings in the unittests I am not sure how the structure of the test cases is and what are the intentions behind all that classes and cases. Because of that I decided just to create a new test class focusing on `to_excel()` only.